### PR TITLE
REVERT: Muda o trigger do deploy de volta pra main

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - develop
+      - main 
       - Github-Actions
     
 permissions:


### PR DESCRIPTION
Salve galera! Há uns tempos eu lancei o #27 que mudava o trigger do deploy pra develop pra atualizar o docusaurus com base nele

poreeem fui avisado exatamente agora que não temos mais develop kkkkkkk aí mudei de volta o trigger pra main, senao ele n funciona o deploy automatico